### PR TITLE
Add codecov action

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,23 @@
+name: Codecov
+on:
+  pull_request:
+    branches: [ master ]
+jobs:
+  codecov:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # https://nodejs.org/en/about/releases/
+        node-version: ['12', '14', '16']
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Install dependencies
+      run: npm ci
+    - name: Run the tests
+      run: npm test
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v2


### PR DESCRIPTION
close #407

cf. [JavaScript Code Coverage Using Github Actions and Codecov - Codecov](https://about.codecov.io/blog/javascript-code-coverage-using-github-actions-and-codecov/)